### PR TITLE
Downgraded Symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "psy/psysh": "~0.4",
-        "symfony/framework-bundle": "~2.7"
+        "symfony/framework-bundle": "~2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",


### PR DESCRIPTION
Downgraded `symfony/framework-bundle` package to the `2.3` version.

Fixes #7