### PR TITLE
Simplify psy/psysh dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "psy/psysh": "~0.5||~0.4||~0.3",
+        "psy/psysh": "^0.3||^0.4||^0.5",
         "symfony/framework-bundle": "~2.3"
     },
     "require-dev": {


### PR DESCRIPTION
Both `0.4` and `0.5` will be included in `~0.3`.

This is not necessary to specify it.