### PR TITLE
Fix the AppKernel.php path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ You can use [Composer](https://getcomposer.org/) to install the bundle to your p
 composer require --dev theofidry/psysh-bundle
 ```
 
-Then, enable the bundle by updating your `app/config/AppKernel.php` file to enable the bundle:
+Then, enable the bundle by updating your `app/AppKernel.php` file to enable the bundle:
 ```php
 <?php
-// app/config/AppKernel.php
+// app/AppKernel.php
 
 public function registerBundles()
 {


### PR DESCRIPTION
Correct the path to AppKernel.php:
AppKernel.php is in `app/` not `app/config/`.