### PR TITLE
PsySH dependency update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "psy/psysh": "^0.3||^0.4||^0.5",
+        "psy/psysh": "~0.3",
         "symfony/framework-bundle": "~2.3"
     },
     "require-dev": {


### PR DESCRIPTION
Loosen the PsySH dependency as has no stable version planned.

Closes #18 