### PR TITLE
Added Facade and function support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ vendor
 composer.lock
 tests/Functional/cache
 tests/Functional/logs
+phpunit.xml
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ matrix:
 
 before_install:
     - if ([ "hhvm" != "$TRAVIS_PHP_VERSION" ] && [ "nightly" != "$TRAVIS_PHP_VERSION" ]); then wget https://scrutinizer-ci.com/ocular.phar; fi
-    - composer self-update
 
 install:
-    - composer install
+    - composer install --prefer-dist
 
 script:
     - vendor/bin/phpunit -c phpunit.xml.dist --coverage-text

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ What does it do exactly?
 | `$kernel`             | Instance of Symfony Kernel           |
 | `$parameters`         | Instance of Symfony parameters       |
 
-Aside from that it's the plain old [PsySH][1]!
+Aside from that it's the plain old [PsySH][1]! You can also [customize it](src/Resources/doc/custom.md) to add your own variables.
 
 
 ## Documentation
@@ -61,6 +61,12 @@ public function registerBundles()
 
 ```bash
 php app/console psysh
+```
+
+or
+
+```php
+psysh()
 ```
 
 ![PsySH Shell](src/Resources/doc/images/shell.png)

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,19 @@
     ],
     "require": {
         "psy/psysh": "~0.3",
-        "symfony/framework-bundle": "~2.3"
+        "symfony/framework-bundle": "~2.3|3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
-        "symfony/symfony": "~2.7"
+        "symfony/symfony": "~2.7|3.0"
     },
     "autoload": {
-        "psr-4": { "Fidry\\PsyshBundle\\": "src" }
+        "psr-4": {
+            "Fidry\\PsyshBundle\\": "src"
+        },
+        "files": [
+            "src/Support/psysh.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": { "Fidry\\PsyshBundle\\Tests\\": "tests" }

--- a/src/Command/PsyshCommand.php
+++ b/src/Command/PsyshCommand.php
@@ -20,21 +20,21 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @author Adrian PALMER <navitronic@gmail.com>
  * @author Théo FIDRY    <theo.fidry@gmail.com>
  */
-class PsyshCommand extends Command
+final class PsyshCommand extends Command
 {
     /**
      * @var Shell
      */
-    private $psyshShell;
+    private $shell;
 
     /**
-     * @param Shell $psyshShell
+     * @param Shell $shell
      */
-    public function __construct(Shell $psyshShell)
+    public function __construct(Shell $shell)
     {
         parent::__construct();
 
-        $this->psyshShell = $psyshShell;
+        $this->shell = $shell;
     }
 
     /**
@@ -52,6 +52,6 @@ class PsyshCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->psyshShell->debug($this->psyshShell->getScopeVariables());
+        $this->shell->debug($this->shell->getScopeVariables());
     }
 }

--- a/src/DependencyInjection/Psysh.php
+++ b/src/DependencyInjection/Psysh.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the PsyshBundle package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fidry\PsyshBundle\DependencyInjection;
+
+use Psy\Shell;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class Psysh
+{
+    /**
+     * @var Shell
+     */
+    private static $shell;
+
+    public static function init(Shell $shell)
+    {
+        self::$shell = $shell;
+    }
+
+    public static function debug(array $variables = [], $bind = null)
+    {
+        $_variables = array_merge(self::$shell->getScopeVariables(), $variables);
+
+        extract(
+            self::$shell->debug($_variables, $bind)
+        );
+    }
+
+    public static function getInstance()
+    {
+        return self::$shell;
+    }
+}

--- a/src/DependencyInjection/PsyshExtension.php
+++ b/src/DependencyInjection/PsyshExtension.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  *
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
-class PsyshExtension extends Extension
+final class PsyshExtension extends Extension
 {
     /**
      * {@inheritdoc}

--- a/src/PsyshBundle.php
+++ b/src/PsyshBundle.php
@@ -11,12 +11,23 @@
 
 namespace Fidry\PsyshBundle;
 
+use Fidry\PsyshBundle\DependencyInjection\Psysh;
+use Psy\Shell;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Adrian PALMER <navitronic@gmail.com>
  * @author Théo FIDRY    <theo.fidry@gmail.com>
  */
-class PsyshBundle extends Bundle
+final class PsyshBundle extends Bundle
 {
+    public function boot()
+    {
+        parent::boot();
+
+        /* @var Shell $shell */
+        $shell = $this->container->get('psysh.shell');
+        Psysh::init($shell);
+    }
+
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,7 +5,10 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="psysh.config" class="Psy\Configuration" />
+
         <service id="psysh.shell" class="Psy\Shell">
+            <argument type="service" id="psysh.config" />
             <call method="setScopeVariables">
                 <argument type="collection">
                     <argument key="container" type="service" id="service_container" />
@@ -15,7 +18,7 @@
             </call>
         </service>
 
-        <service id="psysh.command.shell_command" class="Fidry\PsyshBundle\Command\PsyshCommand" lazy="true">
+        <service id="psysh.command.shell_command" class="Fidry\PsyshBundle\Command\PsyshCommand">
             <argument type="service" id="psysh.shell" />
             <tag name="console.command" />
         </service>

--- a/src/Resources/doc/breakpoint.md
+++ b/src/Resources/doc/breakpoint.md
@@ -14,7 +14,28 @@ php -S localhost:9000 vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/
 To use a breakpoint with PsySH, use the following:
 
 ```php
-eval(\Psy\sh());
+psysh();
+```
+
+You can also pass additional parameters:
+
+```php
+psysh(['myVar' => $myVar);
+```
+
+Which will give you access to `$myVar` in the shell. But to avoid to have to pass all variables, you might simply want
+to bind the shell to you current context:
+
+```php
+class Dummy
+{
+    function myFunction() {
+        $x = 'hello World!';
+        psysh([], $this);
+        
+        // you will have access to $x in your instance
+    }
+}
 ```
 
 Previous chapter: [Reflect like a boss](reflect.md)<br/>

--- a/src/Support/psysh.php
+++ b/src/Support/psysh.php
@@ -1,0 +1,8 @@
+<?php
+
+if (! function_exists('psysh')) {
+    function psysh(array $variables = [], $bind = null)
+    {
+        \Fidry\PsyshBundle\DependencyInjection\Psysh::debug($variables, $bind);
+    }
+}

--- a/tests/Command/PsyshCommandTest.php
+++ b/tests/Command/PsyshCommandTest.php
@@ -12,9 +12,13 @@
 namespace Fidry\PsyshBundle\Tests\Command;
 
 use Fidry\PsyshBundle\Command\PsyshCommand;
+use Fidry\PsyshBundle\DependencyInjection\Psysh;
 use Psy\Shell;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @coversDefaultClass Fidry\PsyshBundle\Command\PsyshCommand
@@ -58,7 +62,7 @@ class PsyshCommandTest extends KernelTestCase
         );
     }
 
-    public function testExecute()
+    public function testFindShell()
     {
         $application = new Application(self::$kernel);
         $application->add($this->command);

--- a/tests/DependencyInjection/PsyshExtensionTest.php
+++ b/tests/DependencyInjection/PsyshExtensionTest.php
@@ -14,6 +14,7 @@ namespace Fidry\PsyshBundle\Tests\DependencyInjection;
 use Fidry\PsyshBundle\DependencyInjection\PsyshExtension;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
@@ -43,12 +44,12 @@ class PsyshExtensionTest extends \PHPUnit_Framework_TestCase
     public function testIsExtensionEnabled()
     {
         $containerBuilderProphecy = $this->getBaseContainerBuiderProphecy();
-
+        /* @var ContainerBuilder $containerBuilder */
         $containerBuilder = $containerBuilderProphecy->reveal();
 
         $extension = new PsyshExtension();
 
-        $extension->load([], $containerBuilderProphecy->reveal());
+        $extension->load([], $containerBuilder);
 
         $this->assertTrue(true, 'Expected no error to be thrown.');
     }
@@ -71,6 +72,13 @@ class PsyshExtensionTest extends \PHPUnit_Framework_TestCase
 
         $containerBuilderProphecy
             ->setDefinition(
+                'psysh.config',
+                $this->definition('Psy\Configuration')
+            )
+            ->shouldBeCalled()
+        ;
+        $containerBuilderProphecy
+            ->setDefinition(
                 'psysh.shell',
                 $this->definition('Psy\Shell')
             )
@@ -84,6 +92,7 @@ class PsyshExtensionTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalled()
         ;
 
+        $containerBuilderProphecy->getDefinition('psysh.config')->willReturn(new Definition());
         $containerBuilderProphecy->getDefinition('psysh.shell')->willReturn(new Definition());
         $containerBuilderProphecy->getParameterBag()->willReturn(new ParameterBag());
 


### PR DESCRIPTION
Add a configuration service to make the configuration of the shell easier. Also improved some classes to make them final and added a function `psysh` to be able to call the shell directly for breakpoints.

Proposed change:

- Create a `Psy\Configuration` service named `psysh.config`
- Use `psy.config` service as the `psy.shell` shell configuration
- Add a facade `Psysh` to be able to get a shell instance statically and call the debug function
- Add a `psysh` function as a shortcut for the facade
- Made all clases final
- Add tests for PHP7
- Upgraded dependencies