### PR TITLE
Add extension points for custom variables and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ What does it do exactly?
 | `$kernel`             | Instance of Symfony Kernel           |
 | `$parameters`         | Instance of Symfony parameters       |
 
-Aside from that it's the plain old [PsySH][1]! You can also [customize it](src/Resources/doc/custom.md) to add your own variables.
+Aside from that it's the plain old [PsySH][1]! You can also [customize it](#customize-psysh) to add your own variables.
 
 
 ## Documentation
@@ -60,6 +60,10 @@ public function registerBundles()
 ## Usage
 
 ```bash
+# Symfony > 3.0
+php bin/console psysh
+
+# Symfony < 3.0
 php app/console psysh
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,50 +114,35 @@ services:
 > PsyshBundle provides autoconfiguration for custom Psysh command services, as long as they inherit from
 > `Psy\Command\ReflectingCommand` or `Psy\Command\Command`.
 
-You may also want to change the parameters. To achieve that, simply override the
-`psysh.shell` service declaration:
+### Adding custom variables
+It is possible to add custom variables to the shell via configuration.
+Variables can be of any type, container parameters references (e.g. `%kernel.debug`) or even services
+(prefixed with `@`, e.g. `"@my_service"`).
 
 ```yaml
 # app/config/config_dev.yml
 
-services:
-    psysh.shell:
-        class: Psy\Shell
-        calls:
-            - method: setScopeVariables
-              arguments:
-                -
-                    container: '@service_container'
-                    session: '@session'
+psysh:
+    variables:
+        foo: bar
+        router: "@router"
+        some: [thing, else]
+        debug: "%kernel.debug%"
 ```
 
-Now if you run `php app/console psysh` and then `ls`, you will see the variables `$container` and `$session`:
+Now if you run `php app/console psysh` and then `ls`, you will see the variables `$foo`, `$router`, `$some` and `$debug`,
+in addition to already defined variables:
 
 ```
 >>> ls
-Variables: $container, $session
+Variables: $foo, $router, $some, $debug...
 ```
 
-The default configuration is the following:
-
-```yaml
-# app/config/config_dev.yml
-
-services:
-    psysh.shell:
-        class: Psy\Shell
-        calls:
-            - method: setScopeVariables
-              arguments:
-                -
-                    kernel: '@kernel'
-                    container: '@service_container'
-                    parameters: '@=service("service_container").getParameterBag().all()'
-```
-
-**Note: PsyshBundle is by default registered to the Kernel only in dev/test environment and so are the bundle package.
-If you override the service declaration, ensure that it will not occur in production. You can declare your service
-in `app/config/config_dev.yml` for example or create a new `app/config/services_dev.yml` that will be imported only in dev.**
+Default variables are:
+- `$container` (the service container)
+- `$kernel`
+- `$parameters` (all container parameters)
+- `$self` (the PsySH shell itself)
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -84,8 +84,33 @@ class X
 
 ## Customize PsySH
 
+### Adding a custom command
+Adding a custom command for PsySH is as simple as defining a service with `psysh.command` tag!
 
-You may also want to add a custom command or change the parameters. To achieve that, simply override the
+```yaml
+services:
+    my_psysh_command:
+        class: Acme\Shell\MyCommand
+        tags:
+            - { name: psysh.command }
+```
+
+Or even simpler if you use Symfony 3.3+:
+
+```yaml
+services:
+    _defaults:
+        autonfigure: true
+        autowire: true
+        public: false
+
+    Acme\Shell\MyCommand: ~
+```
+
+> PsyshBundle provides autoconfiguration for custom Psysh command services, as long as they inherit from
+> `Psy\Command\ReflectingCommand` or `Psy\Command\Command`.
+
+You may also want to change the parameters. To achieve that, simply override the
 `psysh.shell` service declaration:
 
 ```yaml

--- a/resources/config/services.xml
+++ b/resources/config/services.xml
@@ -11,7 +11,7 @@
             </call>
         </service>
 
-        <service id="psysh.shell" class="Psy\Shell">
+        <service id="psysh.shell" class="Psy\Shell" public="false">
             <argument type="service" id="psysh.config" />
             <call method="setScopeVariables">
                 <argument type="collection">

--- a/resources/config/services.xml
+++ b/resources/config/services.xml
@@ -13,16 +13,6 @@
 
         <service id="psysh.shell" class="Psy\Shell" public="false">
             <argument type="service" id="psysh.config" />
-            <call method="setScopeVariables">
-                <argument type="collection">
-                    <argument key="container" type="service" id="service_container" />
-                    <argument key="kernel" type="service" id="kernel" />
-                    <argument key="parameters" type="expression">
-                        service('service_container').getParameterBag().all()
-                    </argument>
-                    <argument key="self" type="service" id="psysh.shell" />
-                </argument>
-            </call>
         </service>
 
         <service id="psysh.command.shell_command" class="Fidry\PsyshBundle\Command\PsyshCommand">

--- a/src/DependencyInjection/Compiler/AddPsyshCommandPass.php
+++ b/src/DependencyInjection/Compiler/AddPsyshCommandPass.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the PsyshBundle package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fidry\PsyshBundle\DependencyInjection\Compiler;
+
+use Psy\Command\Command as PsyshCommand;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass allowing to add Psysh commands dynamically
+ *
+ * @author Jérôme Vieilledent <jerome@vieilledent.fr>
+ */
+class AddPsyshCommandPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('psysh.shell')) {
+            return;
+        }
+
+        $commands = [];
+        foreach ($container->findTaggedServiceIds('psysh.command') as $id => $attributes) {
+            // Workaround to avoid Psysh commands to be registered as regular console commands
+            // (conflict with service autoconfiguration as Psysh commands inherit from \Symfony\Component\Console\Command\Command as well
+            // Note that this compiler pass must run with a higher priority than AddConsoleCommandPass to be efficient.
+            $container->findDefinition($id)->clearTag('console.command');
+            $commands[] = new Reference($id);
+        }
+
+
+        $shellRef = $container->findDefinition('psysh.shell');
+        $shellRef->addMethodCall('addCommands', [$commands]);
+    }
+}

--- a/src/DependencyInjection/Compiler/AddPsyshCommandPass.php
+++ b/src/DependencyInjection/Compiler/AddPsyshCommandPass.php
@@ -20,8 +20,10 @@ use Symfony\Component\DependencyInjection\Reference;
  * Compiler pass allowing to add Psysh commands dynamically
  *
  * @author Jérôme Vieilledent <jerome@vieilledent.fr>
+ *
+ * @private
  */
-class AddPsyshCommandPass implements CompilerPassInterface
+final class AddPsyshCommandPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
@@ -37,7 +39,6 @@ class AddPsyshCommandPass implements CompilerPassInterface
             $container->findDefinition($id)->clearTag('console.command');
             $commands[] = new Reference($id);
         }
-
 
         $shellRef = $container->findDefinition('psysh.shell');
         $shellRef->addMethodCall('addCommands', [$commands]);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the PsyshBundle package.
+ *
+ * (c) Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fidry\PsyshBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('psysh');
+
+        $rootNode
+            ->children()
+                ->arrayNode('variables')
+                    ->info('Define additional variables to be exposed in Psysh')
+                    ->useAttributeAsKey('variable_name')
+                    ->example([
+                        'debug' => '%kernel.debug%',
+                        'my_service' => '@my.service',
+                        'os' => ['linux', 'macos', 'losedows'],
+                    ])
+                    ->prototype('variable')->end()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,7 +14,10 @@ namespace Fidry\PsyshBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @private
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {

--- a/src/DependencyInjection/PsyshExtension.php
+++ b/src/DependencyInjection/PsyshExtension.php
@@ -11,6 +11,7 @@
 
 namespace Fidry\PsyshBundle\DependencyInjection;
 
+use Psy\Command\Command;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -32,5 +33,10 @@ final class PsyshExtension extends Extension
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../../resources/config'));
         $loader->load('services.xml');
+        
+        // Register Psysh commands for service autoconfiguration (Symfony 3.3+)
+        if (method_exists($container, 'registerForAutoconfiguration')) {
+            $container->registerForAutoconfiguration(Command::class)->addTag('psysh.command');
+        }
     }
 }

--- a/src/PsyshBundle.php
+++ b/src/PsyshBundle.php
@@ -11,8 +11,10 @@
 
 namespace Fidry\PsyshBundle;
 
-use Fidry\PsyshBundle\PsyshFacade;
-use Psy\Shell;
+use Fidry\PsyshBundle\DependencyInjection\Compiler\AddPsyshCommandPass;
+use Psy\Command\Command;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -28,4 +30,11 @@ final class PsyshBundle extends Bundle
         $this->container->get('psysh.facade');
     }
 
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        // Ensure that AddPsyshCommandPass runs before AddConsoleCommandPass to avoid autoconfiguration conflicts.
+        $container->addCompilerPass(new AddPsyshCommandPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
+    }
 }


### PR DESCRIPTION
This patch adds the possibility to add custom Psysh commands and custom variables more easily.
Of course documentation has been updated 😉 .

You may note that I had to workaround an issue with service autoconfiguration when applicable (Symfony 3.3+) as `Psy\Command\Command` inherits from `Symfony\Component\Console\Command\Command`, which makes them eligible for regular `console.command` services autoconfig.

### Adding a custom command
Adding a custom command for PsySH is as simple as defining a service with `psysh.command` tag!

```yaml
services:
    my_psysh_command:
        class: Acme\Shell\MyCommand
        tags:
            - { name: psysh.command }
```

Or even simpler if you use Symfony 3.3+:

```yaml
services:
    _defaults:
        autonfigure: true
        autowire: true
        public: false

    Acme\Shell\MyCommand: ~
```

> PsyshBundle provides autoconfiguration for custom Psysh command services, as long as they inherit from
> `Psy\Command\ReflectingCommand` or `Psy\Command\Command`.

### Adding custom variables
It is possible to add custom variables to the shell via configuration.
Variables can be of any type, container parameters references (e.g. `%kernel.debug`) or even services
(prefixed with `@`, e.g. `"@my_service"`).

```yaml
# app/config/config_dev.yml

psysh:
    variables:
        foo: bar
        router: "@router"
        some: [thing, else]
        debug: "%kernel.debug%"
```

Now if you run `php app/console psysh` and then `ls`, you will see the variables `$foo`, `$router`, `$some` and `$debug`,
in addition to already defined variables:

```
>>> ls
Variables: $foo, $router, $some, $debug...