### PR TITLE
Make psysh.facade public so it is not removed from the compiled container

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -13,8 +13,8 @@
 // Debug only
 set_time_limit(0);
 require_once __DIR__.'/../vendor/autoload.php';
-require_once __DIR__.'/../tests/Functional/AppKernel.php';
 
+use Fidry\PsyshBundle\Functional\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/framework-bundle": "^3.4 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.2",
+        "phpunit/phpunit": "^6.4",
         "symfony/symfony": "^3.4 || ^4.0"
     },
 
@@ -36,10 +36,9 @@
         ]
     },
     "autoload-dev": {
-        "psr-4": { "Fidry\\PsyshBundle\\": "tests" },
-        "files": [
-            "tests/Functional/AppKernel.php"
-        ]
+        "psr-4": {
+            "Fidry\\PsyshBundle\\": "tests"
+        }
     },
 
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.4/phpunit.xsd"
          colors="true"
          stopOnFailure="false"
          bootstrap="vendor/autoload.php">
 
     <php>
-        <server name="KERNEL_DIR" value="tests/Functional" />
+        <server name="KERNEL_CLASS" value="Fidry\PsyshBundle\Functional\AppKernel" />
     </php>
 
     <testsuites>

--- a/resources/config/services.xml
+++ b/resources/config/services.xml
@@ -20,7 +20,7 @@
             <tag name="console.command" />
         </service>
 
-        <service id="psysh.facade" class="Fidry\PsyshBundle\PsyshFacade">
+        <service id="psysh.facade" class="Fidry\PsyshBundle\PsyshFacade" public="true">
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>

--- a/resources/config/services.xml
+++ b/resources/config/services.xml
@@ -11,11 +11,11 @@
             </call>
         </service>
 
-        <service id="psysh.shell" class="Psy\Shell" public="false">
+        <service id="psysh.shell" class="Psy\Shell" public="true">
             <argument type="service" id="psysh.config" />
         </service>
 
-        <service id="psysh.command.shell_command" class="Fidry\PsyshBundle\Command\PsyshCommand">
+        <service id="psysh.command.shell_command" class="Fidry\PsyshBundle\Command\PsyshCommand" public="true">
             <argument type="service" id="psysh.shell" />
             <tag name="console.command" />
         </service>

--- a/tests/Command/PsyshCommandUnitTest.php
+++ b/tests/Command/PsyshCommandUnitTest.php
@@ -11,6 +11,7 @@
 
 namespace Fidry\PsyshBundle\Command;
 
+use PHPUnit\Framework\TestCase;
 use Psy\Shell;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
-class PsyshCommandUnitTest extends \PHPUnit_Framework_TestCase
+class PsyshCommandUnitTest extends TestCase
 {
     public function testIsASymfonyCommand()
     {

--- a/tests/Functional/AppKernel.php
+++ b/tests/Functional/AppKernel.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+namespace Fidry\PsyshBundle\Functional;
+
 use Fidry\PsyshBundle\PsyshBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;

--- a/tests/Functional/config.yml
+++ b/tests/Functional/config.yml
@@ -1,9 +1,8 @@
 framework:
-    secret:                  PsyshBundleSecret
+    secret: PsyshBundleSecret
     router:
-        resource:            ~
-        strict_requirements: %kernel.debug%
-    trusted_proxies:         ~
-    test:                    ~
+        resource: ~
+        strict_requirements: '%kernel.debug%'
+    test: ~
     session:
-        storage_id:          session.storage.mock_file
+        storage_id: session.storage.mock_file


### PR DESCRIPTION
Fix for error in Symfony 4: The "psysh.facade" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.