### PR TITLE
Fix Symfony 3.4 and 4

### DIFF
--- a/resources/config/services.xml
+++ b/resources/config/services.xml
@@ -20,7 +20,7 @@
             <tag name="console.command" />
         </service>
 
-        <service id="psysh.facade" class="Fidry\PsyshBundle\PsyshFacade">
+        <service id="psysh.facade" class="Fidry\PsyshBundle\PsyshFacade" public="true">
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>


### PR DESCRIPTION
Mark psysh.facade service as public, so it can be loaded on bundle boot.

Fixes #30 