### PR TITLE
Add support for PsySH v0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 
     "require": {
         "php": "^7.1",
-        "psy/psysh": "^0.8",
+        "psy/psysh": "^0.8 || ^0.9",
         "symfony/expression-language": "^3.4 || ^4.0",
         "symfony/framework-bundle": "^3.4 || ^4.0"
     },


### PR DESCRIPTION
A new version of PsySH came out yesterday. The older version was holding back a lot of useful dependency updates such as [Symfony MakerBundle](https://github.com/symfony/maker-bundle).