### PR TITLE
Avoid deprecation warning when using symfony/config >= 4.2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,8 +21,8 @@ final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('psysh');
+        $treeBuilder = new TreeBuilder('psysh');
+        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('psysh');
 
         $rootNode
             ->children()


### PR DESCRIPTION
This adds a backwards-compatible change to remove the deprecation notice.

fixes #41 