### PR TITLE
Bump PHPUnit version (Close #45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist
 coverage.xml
 bin
 !bin/console
+.phpunit.result.cache
+var
+.idea

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/framework-bundle": "^4.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.2",
+        "phpunit/phpunit": "^7.5",
         "symfony/symfony": "^4.3"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/framework-bundle": "^4.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4",
+        "phpunit/phpunit": "^8.2",
         "symfony/symfony": "^4.3"
     },
 

--- a/tests/Command/PsyshCommandIntegrationTest.php
+++ b/tests/Command/PsyshCommandIntegrationTest.php
@@ -37,7 +37,7 @@ class PsyshCommandIntegrationTest extends KernelTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
 
@@ -47,7 +47,7 @@ class PsyshCommandIntegrationTest extends KernelTestCase
 
     public function testScopeVariables()
     {
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             [
                 'container',
                 'kernel',
@@ -56,10 +56,7 @@ class PsyshCommandIntegrationTest extends KernelTestCase
                 'self',
             ],
             array_keys($this->shell->getScopeVariables()),
-            'Expected shell service to have scope variables',
-            0.0,
-            10,
-            true
+            'Expected shell service to have scope variables'
         );
     }
 


### PR DESCRIPTION
Method `assertEquals` with `$canonicalize` parameter is deprecated now: https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/Assert.php#L585
It is safe to replace it with `assertEqualsCanonicalizing`: https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/Assert.php#L613