### PR TITLE
Remove deprecated Symfony\Component\Debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,18 @@ branches:
     - master
 
 php:
-    - '7.1'
     - '7.2'
     - nightly
 
 matrix:
     fast_finish: true
     include:
-        - php: '7.1'
+        - php: '7.2'
           env:
               - COMPOSER_FLAGS='--prefer-lowest'
-              - SYMFONY_VERSION='~4.3.0'
+              - SYMFONY_VERSION='~4.4.0'
         - php: '7.2'
-          env: SYMFONY_VERSION='~4.3.0'
+          env: SYMFONY_VERSION='~4.4.0'
         - php: '7.2'
           env: SYMFONY_VERSION='^5.0'
     allow_failures:

--- a/bin/console
+++ b/bin/console
@@ -17,7 +17,7 @@ require_once __DIR__.'/../vendor/autoload.php';
 use Fidry\PsyshBundle\Functional\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.1",
         "psy/psysh": "^0.8 || ^0.9",
-        "symfony/error-handler": "^4.3|^4.4|^5.0",
+        "symfony/error-handler": "^4.3|^5.0",
         "symfony/expression-language": "^4.3|^5.0",
         "symfony/framework-bundle": "^4.3|^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     ],
 
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "psy/psysh": "^0.8 || ^0.9",
-        "symfony/error-handler": "^4.3|^5.0",
-        "symfony/expression-language": "^4.3|^5.0",
-        "symfony/framework-bundle": "^4.3|^5.0"
+        "symfony/error-handler": "^4.4|^5.0",
+        "symfony/expression-language": "^4.4|^5.0",
+        "symfony/framework-bundle": "^4.4|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",
-        "symfony/symfony": "^4.3|^5.0"
+        "symfony/symfony": "^4.4|^5.0"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.1",
         "psy/psysh": "^0.8 || ^0.9",
-        "symfony/debug": "^4.3|^4.4",
+        "symfony/debug": "^4.4",
         "symfony/expression-language": "^4.3|^5.0",
         "symfony/framework-bundle": "^4.3|^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.1",
         "psy/psysh": "^0.8 || ^0.9",
-        "symfony/debug": "^4.4",
+        "symfony/error-handler": "^4.3|^4.4|^5.0",
         "symfony/expression-language": "^4.3|^5.0",
         "symfony/framework-bundle": "^4.3|^5.0"
     },


### PR DESCRIPTION
Replace deprecated `Symfony\Component\Debug` with `Symfony\ErrorHandler\Debug`

`Symfony\Component\Debug` has been deprecated since Symfony 4.4
The `ErrorHandler\Debug` component has support for Symfony 4.3 so that is no problem