### PR TITLE
Allow PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
 
     "require": {
-        "php": "^7.3|^8.0",
+        "php": ">=7.3",
         "psy/psysh": "^0.10",
         "symfony/error-handler": "^5.0|^4.4",
         "symfony/expression-language": "^5.0|^4.4",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
 
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "psy/psysh": "^0.10",
         "symfony/error-handler": "^5.0|^4.4",
         "symfony/expression-language": "^5.0|^4.4",


### PR DESCRIPTION
I am attempting to use this with a code base that is using PHP 8.0 and have been able to perform some very minor smoke testing locally.

I've opted to set the version constraint to ">=7.3" rather than "^7.3|^8.0", using packages like [api-platform/core](https://github.com/api-platform/core/blob/master/composer.json) as a guide, though this is certainly up for discussion.