### PR TITLE
Fix "Return value must be of the type int" on Symfony 5.3

### DIFF
--- a/src/Command/PsyshCommand.php
+++ b/src/Command/PsyshCommand.php
@@ -29,6 +29,8 @@ final class PsyshCommand extends Command
         parent::__construct();
 
         $this->psysh = $psysh;
+        
+        return 0;
     }
 
     protected function configure(): void


### PR DESCRIPTION
Fixes #62 

Since the bundle currently supports Symfony >= 4.4, and returning 0 is already supported in 4.4,
we can simply always return 0