### PR TITLE
Adapt constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     ],
 
     "require": {
-        "php": ">=7.3",
-        "psy/psysh": "^0.10",
-        "symfony/error-handler": "^5.0|^4.4",
-        "symfony/expression-language": "^5.0|^4.4",
-        "symfony/framework-bundle": "^5.0|^4.4"
+        "php": ">=8.0",
+        "psy/psysh": "^0.11",
+        "symfony/error-handler": "^5.4|^6.0",
+        "symfony/expression-language": "^5.4|^6.0",
+        "symfony/framework-bundle": "^5.4|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
-        "symfony/symfony": "^5.0|^4.4"
+        "phpunit/phpunit": "^9.5",
+        "symfony/symfony": "^5.4|^6.0"
     },
 
     "autoload": {


### PR DESCRIPTION
- Bump minimum PHP version to 8.0
- Allow installation with Symfony 6.0
- Remove support for Symfony 4.x

The project & CI will be fixed in another PR.