### PR TITLE
Add support for psysh 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,13 @@
 
     "require": {
         "php": ">=8.0",
-        "psy/psysh": "^0.11",
+        "psy/psysh": "^0.12 || ^0.11",
         "symfony/error-handler": "^5.4|^6.0",
         "symfony/expression-language": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0"
     },
     "require-dev": {
+        "monolog/monolog": "^3.5",
         "phpunit/phpunit": "^9.5",
         "symfony/symfony": "^5.4|^6.0"
     },


### PR DESCRIPTION
- Ran tests and these are all green
- Had to add the `monolog/monolog` dependency to run tests properly as this seems to be a hidden dependency

This PR exists because I need psysh 0.12 support, because I need nikic/php-parser 5 support because I want to upgrade to PHPunit 11 